### PR TITLE
Update the code to use the derived variable logic in ADIOS2

### DIFF
--- a/src/hermes_engine.cc
+++ b/src/hermes_engine.cc
@@ -228,7 +228,10 @@ void HermesEngine::ComputeDerivedVariables()
 
         for (auto derivedBlock : DerivedBlockData)
         {
-            // TODO DoPutDerived(*(*it).second.get(), std::get<0>(derivedBlock), true /* sync */);
+#define DEFINE_VARIABLE_PUT(T) \
+            PutDerived(derivedVar, static_cast<T *>(std::get<0>(derivedBlock));
+  ADIOS2_FOREACH_ATTRIBUTE_PRIMITIVE_STDTYPE_1ARG(DEFINE_VARIABLE_PUT)
+#undef DEFINE_VARIABLE_PUT
             free(std::get<0>(derivedBlock));
 
         }
@@ -390,7 +393,7 @@ void HermesEngine::DoPutDeferred_(
 
 template<typename T>
 void HermesEngine::PutDerived(
-    const adios2::core::DefinedVariable<T> &variable, const T *values) {
+    const adios2::core::VariableDerived &variable, const T *values) {
   engine_logger->info("rank {}", rank);
   std::string name = variable.m_Name;
   Hermes->bkt->Put(name, variable.SelectionSize() * sizeof(T), values);


### PR DESCRIPTION
The `m_IO` variable can be used to keep track and compute values for derived variables defined in ADIOS2

The API on the application side is:
```
auto var1 = bpIO.DefineVariable<float>("vx", {Nz, Ny, size * Nx}, {0, 0, rank * Nx}, {Nz, Ny, Nx});
auto var2 = bpIO.DefineVariable<float>("vy", {Nz, Ny, size * Nx}, {0, 0, rank * Nx}, {Nz, Ny, Nx});

auto magU = bpIO.DefineDerivedVariable("derive/magU",
                                           "x:vx \n"
                                           "y:vy \n"
                                           "magnitude(x,y)",
                                           adios2::DerivedVarType::StoreData);
```

The changes to the Hermes engine are only in the `EndStep` function:
- Parse over all derived variables (check if the variables exist - in the e.g. check if vx and vy are defined)
- Get the data pointer from Hermes and convert it to the format expected by the compute functions
- Compute the values for the derived variable
- Call `PutDerived` with the derived variable and the new values
- Free the temporary buffer with the values

**NOTE** I did not compiled and ran this yet